### PR TITLE
Expose header_appendix and image_appendix parameters

### DIFF
--- a/eigerApp/Db/eiger.template
+++ b/eigerApp/Db/eiger.template
@@ -386,6 +386,32 @@ record(bi,"$(P)$(R)StreamEnable_RBV") {
     field(SCAN, "I/O Intr")
 }
 
+record(stringout, "$(P)$(R)StreamHeaderAppx") {
+    field(PINI, "YES")
+    field(DTYP, "asynOctetWrite")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))STREAM_HEADER_APPX")
+    field(VAL,  "")
+}
+
+record(stringin, "$(P)$(R)StreamHeaderAppx_RBV") {
+    field(DTYP, "asynOctetRead")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))STREAM_HEADER_APPX")
+    field(SCAN, "I/O Intr")
+}
+
+record(stringout, "$(P)$(R)StreamImageAppx") {
+    field(PINI, "YES")
+    field(DTYP, "asynOctetWrite")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))STREAM_IMAGE_APPX")
+    field(VAL,  "")
+}
+
+record(stringin, "$(P)$(R)StreamImageAppx_RBV") {
+    field(DTYP, "asynOctetRead")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))STREAM_IMAGE_APPX")
+    field(SCAN, "I/O Intr")
+}
+
 # Stream number of dropped frames
 record(ai, "$(P)$(R)StreamDropped_RBV")
 {

--- a/eigerApp/src/eigerDetector.cpp
+++ b/eigerApp/src/eigerDetector.cpp
@@ -270,6 +270,8 @@ eigerDetector::eigerDetector (const char *portName, const char *serverHostname,
     // Stream API Parameters
     mStreamEnable     = mParams.create(EigStreamEnableStr,    asynParamInt32, SSStreamConfig, "mode");
     mStreamEnable->setEnumValues(modeEnum);
+    mStreamHeaderAppx = mParams.create(EigStreamHeaderAppx,   asynParamOctet, SSStreamConfig, "header_appendix");
+    mStreamImageAppx  = mParams.create(EigStreamImageAppx,    asynParamOctet, SSStreamConfig, "image_appendix");
     mStreamState      = mParams.create(EigStreamStateStr,     asynParamOctet, SSStreamStatus, "state");
     mStreamDropped    = mParams.create(EigStreamDroppedStr,   asynParamInt32, SSStreamStatus, "dropped");
 

--- a/eigerApp/src/eigerDetector.h
+++ b/eigerApp/src/eigerDetector.h
@@ -72,6 +72,8 @@
 
 // Stream API Parameters
 #define EigStreamEnableStr         "STREAM_ENABLE"
+#define EigStreamHeaderAppx        "STREAM_HEADER_APPX"
+#define EigStreamImageAppx         "STREAM_IMAGE_APPX"
 #define EigStreamDroppedStr        "STREAM_DROPPED"
 #define EigStreamStateStr          "STREAM_STATE"
 
@@ -169,6 +171,8 @@ protected:
 
     // Eiger parameters: streaming interface
     EigerParam *mStreamEnable;
+    EigerParam *mStreamHeaderAppx;
+    EigerParam *mStreamImageAppx;
     EigerParam *mStreamDropped;
     EigerParam *mStreamState;
 


### PR DESCRIPTION
We are using these specifically to store a file name for an acquisition in the stream metadata, but it seems like it would be generally useful.